### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Installation
 Requirements
 ============
 
-* XCode 7 and higher
+* Xcode 7 and higher
 * Swift 2
 * iOS 8 and higher / tvOS 9.0 and higher
 


### PR DESCRIPTION

This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
