### PR TITLE
Fix issue for iOS9 new move behavior.

### DIFF
--- a/DTModelStorage.podspec
+++ b/DTModelStorage.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'DTModelStorage'
-  s.version  = '1.3.3'
+  s.version  = '1.3.4'
   s.license  = 'MIT'
   s.summary  = 'Storage classes for datasource based controls.'
   s.homepage = 'https://github.com/DenHeadless/DTModelStorage'

--- a/DTModelStorage/CoreData/DTCoreDataStorage.m
+++ b/DTModelStorage/CoreData/DTCoreDataStorage.m
@@ -136,16 +136,18 @@
     {
         if ([indexPath compare:newIndexPath] == NSOrderedSame)
         {
-            return;
-        }
-        if ([self.currentUpdate.insertedSectionIndexes containsIndex:newIndexPath.section] == NO)
+            [self.currentUpdate.updatedRowIndexPaths addObject:indexPath];
+        } else
         {
-            [self.currentUpdate.insertedRowIndexPaths addObject:newIndexPath];
-        }
+            if ([self.currentUpdate.insertedSectionIndexes containsIndex:newIndexPath.section] == NO)
+            {
+                [self.currentUpdate.insertedRowIndexPaths addObject:newIndexPath];
+            }
 
-        if ([self.currentUpdate.deletedSectionIndexes containsIndex:indexPath.section] == NO)
-        {
-            [self.currentUpdate.deletedRowIndexPaths addObject:indexPath];
+            if ([self.currentUpdate.deletedSectionIndexes containsIndex:indexPath.section] == NO)
+            {
+                [self.currentUpdate.deletedRowIndexPaths addObject:indexPath];
+            }
         }
     } else if (type == NSFetchedResultsChangeUpdate)
     {


### PR DESCRIPTION
**Environment**: 
- `Foo: NSManagedObject` with some property `date`.
- `DTCollectionViewController` that use `DTCoreDataStorage` with `NSFetchedResultsController` against `Foo`, and sort by `date`.

When we update this `date` in iOS 8 and earlier its will be trigger `NSFetchedResultsController `'s delegate with type `NSFetchedResultsChangeUpdate` and all be fine. But in iOS 9 it will be triggered with type `NSFetchedResultsChangeMove` with same indexes. And in 1.3.3 version it will be ignored by `return`. I just change it to do update instead.