### PR TITLE
Fixed read only Realm database exception

### DIFF
--- a/Source/Realm/RealmStorage.swift
+++ b/Source/Realm/RealmStorage.swift
@@ -86,10 +86,12 @@ open class RealmStorage : BaseStorage, Storage, SupplementaryStorage, SectionLoc
         } else {
             sections[index] = section
         }
-        let sectionIndex = sections.count - 1
-        notificationTokens[index] = results.addNotificationBlock({ [weak self] change in
-            self?.handleChange(change, inSection: sectionIndex)
-        })
+        if results.realm?.configuration.readOnly == false {
+            let sectionIndex = sections.count - 1
+            notificationTokens[index] = results.addNotificationBlock({ [weak self] change in
+                self?.handleChange(change, inSection: sectionIndex)
+                })
+        }
         delegate?.storageNeedsReloading()
     }
     


### PR DESCRIPTION
There's a problem with the RealmStorage setSection function when the realm database is read only.
You get an exception when adding the notification block to the results because 'Read-only Realms do not change and do not have change notifications'.

We should check that before adding the notification block.