### PR TITLE
update + insert in one transaction iOS 10 fix

### DIFF
--- a/Source/Core/CoreDataStorage.swift
+++ b/Source/Core/CoreDataStorage.swift
@@ -136,8 +136,14 @@ open class CoreDataStorage<T: NSFetchRequestResult> : BaseStorage, Storage, Supp
             }
         case .update:
             if let indexPath = indexPath {
-                currentUpdate?.objectChanges.append((.update, [indexPath]))
-                currentUpdate?.updatedObjects[indexPath] = anObject
+                if let new = newIndexPath, indexPath != indexPath {
+                    currentUpdate?.objectChanges.append((.delete,[indexPath]))
+                    currentUpdate?.objectChanges.append((.insert,[new]))
+                }
+                else {
+                    currentUpdate?.objectChanges.append((.update,[indexPath]))
+                    currentUpdate?.updatedObjects[indexPath] = anObject
+                }
             }
         }
     }


### PR DESCRIPTION
Before iOS 10 transactions with update and insertions had .move NSFetchedResultsChangeType and all worked fine, but now it is .update