### PR TITLE
Allow other `RealmCollection` types to be added as a section

### DIFF
--- a/Source/Realm/RealmSection.swift
+++ b/Source/Realm/RealmSection.swift
@@ -39,7 +39,7 @@ protocol ItemAtIndexPathRetrievable {
 open class RealmSection<T: Object> : SupplementaryAccessible, Section, ItemAtIndexPathRetrievable {
     
     /// Results object
-    open var results: Results<T>
+    open var results: AnyRealmCollection<T>
     
     /// delegate, that knows about current section index in storage.
     open weak var sectionLocationDelegate: SectionLocationIdentifyable?
@@ -54,7 +54,7 @@ open class RealmSection<T: Object> : SupplementaryAccessible, Section, ItemAtInd
     
     /// Creates RealmSection with Realm.Results
     /// - Parameter results: results of Realm objects query
-    public init(results: Results<T>) {
+    public init(results: AnyRealmCollection<T>) {
         self.results = results
     }
     

--- a/Source/Realm/RealmStorage.swift
+++ b/Source/Realm/RealmStorage.swift
@@ -67,7 +67,7 @@ open class RealmStorage: BaseStorage, Storage, SupplementaryStorage, SectionLoca
     }
     
     /// Adds `RealmSection`, containing `results`.
-    open func addSection<T: Object>(with results: Results<T>) {
+    open func addSection<T:RealmCollection>(with results: T) where T.Element: Object {
         setSection(with: results, forSection: sections.count)
     }
     
@@ -75,10 +75,10 @@ open class RealmStorage: BaseStorage, Storage, SupplementaryStorage, SectionLoca
     ///
     ///  Calls `delegate.storageNeedsReloading()` after section is set. Subscribes for Realm notifications to automatically update section when update occurs.
     /// - Note: if index is less than number of section, this method won't do anything.
-    open func setSection<T: Object>(with results: Results<T>, forSection index: Int) {
+    open func setSection<T:RealmCollection>(with results: T, forSection index: Int) where T.Element: Object {
         guard index <= sections.count else { return }
         
-        let section = RealmSection(results: results)
+        let section = RealmSection(results: AnyRealmCollection(results))
         notificationTokens[index]?.stop()
         notificationTokens[index] = nil
         if index == sections.count {

--- a/Tests/Realm/RealmStorageTestCase.swift
+++ b/Tests/Realm/RealmStorageTestCase.swift
@@ -40,6 +40,33 @@ class RealmStorageTestCase: XCTestCase {
         }
     }
     
+    func giveDogs(names: [String], to personName: String) -> Person {
+        let person = Person()
+        try! realm.write {
+            person.name = personName
+            realm.add(person)
+
+            let dogs = names.map{(name: String) -> Dog in
+                let dog = Dog()
+                dog.name = name
+                realm.add(dog)
+                return dog
+            }
+            
+            person.dogs.append(objectsIn: dogs)
+        }
+        
+        return person
+    }
+        
+    func testRealmStorageAddList() {
+        let person = giveDogs(names: ["Rex", "Spot"], to: "Joe")
+        
+        storage.addSection(with: person.dogs)
+        
+        expect((self.storage.item(at: indexPath(1, 0)) as? Dog)?.name) == "Spot"
+    }
+    
     func testRealmStorageHandlesSectionAddition() {
         addDogNamed("Rex")
         


### PR DESCRIPTION
re #16 

DTModelStorage allowed for adding `Results` as a section. While this is the most obvious case, `List` and `LinkingObjects` share a common protocol with `Results` called `RealmCollection`. All three types can be accessed in the same ways, and also all have the ability to be observed by calling `addNotificationBlock`

This change makes use of the `RealmCollection` protocol, and stores the collection as an `AnyRealmCollection`. 